### PR TITLE
using boto3 client to load data into inframock & pinned dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-boto3
-requests
-backoff
-cfn_flip
-simplejson
+boto3==1.17.82
+requests==2.25.1
+backoff==1.10.0
+cfn-flip==1.2.3


### PR DESCRIPTION
Using lower level client in `biomage-utils` which returns unmarshalled json (json annotated with dynamodb info which is valid json -> without sets). This remove all saving problems as the json is valid and then in inframock we can just load the data using the same low-level client.

## Code changes

There's some renaming but the only real changes are using `boto3.client` instead of `dynamo.Table` and not needing simplejson anymore.

Related PR 

https://github.com/biomage-ltd/biomage-utils/pull/33