### PR TITLE
removing restart:always for postgre container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,6 @@ services:
   postgres:
     container_name: "biomage-inframock-postgres"
     image: "postgres:13-alpine"
-    restart: always
     ports:
       - "5431:5432"
     volumes:

--- a/src/postgres_init/schema.sql
+++ b/src/postgres_init/schema.sql
@@ -5,12 +5,12 @@ CREATE DATABASE aurora_db;
 \c aurora_db;
 
 -- The role used by the api & develop
-CREATE ROLE api_role WITH LOGIN PASSWORD 'password';
-CREATE ROLE dev_role WITH LOGIN PASSWORD 'password';
-
+CREATE ROLE api_role WITH LOGIN;
+CREATE ROLE dev_role WITH LOGIN;
 GRANT USAGE ON SCHEMA public TO api_role;
-GRANT USAGE ON SCHEMA public TO dev_role;
-
--- Gives these privileges to api_role on any table that we create in public
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO api_role;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO dev_role;
+-- RDS doesnt allow master user some things, so we need to
+-- grant and later revoke dev_role from postgres to move its privileges
+GRANT dev_role TO postgres;
+ALTER DEFAULT PRIVILEGES FOR USER dev_role IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO api_role;
+REVOKE dev_role FROM postgres;
+GRANT postgres TO dev_role;


### PR DESCRIPTION
@cosa65 afaik the `restart:always` is not needed and it causes the container to:
1. to be started when the computer boots up
2. try to restart it when shutting down inframock (thus leading to 10 s. wait instead of instakill)

The other changes are just the updates you sent to me.