### PR TITLE
Fix inframock cleanup of postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ cython_debug/
 # Disable uploading for local data cache for using local data
 src/data/
 data/
+pg_data/

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run: build ## Builds & runs the docker environment
 migrate:
 	@NODE_ENV=development knex migrate:latest --cwd ../api/src/sql/ --migrations-directory ../api/src/sql/migrations
 cleanup-sql:
-	docker rm -f -v biomage-inframock-postgres
+	docker rm -f -v biomage-inframock-postgres && rm -rf pg_data
 reload-data: migrate ## Reloads the input data found in ./data. NOTE: it will not remove from s3 & dynamo generated data like processed matrices, or plots. If you need a clean start, stop & re-run inframock.
 	@docker-compose $(docker_files)  up -d --no-deps --build service
 .PHONY: bootstrap fmt check build run clean help

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run: build ## Builds & runs the docker environment
 migrate:
 	@NODE_ENV=development knex migrate:latest --cwd ../api/src/sql/ --migrations-directory ../api/src/sql/migrations
 cleanup-sql:
-	docker rm -f -v biomage-inframock-postgres && rm -rf pg_data
+	rm -rf pg_data
 reload-data: migrate ## Reloads the input data found in ./data. NOTE: it will not remove from s3 & dynamo generated data like processed matrices, or plots. If you need a clean start, stop & re-run inframock.
 	@docker-compose $(docker_files)  up -d --no-deps --build service
 .PHONY: bootstrap fmt check build run clean help


### PR DESCRIPTION
There were some changes made to postgres so that the data of the db is stored in `pg_data` but the makefile command to reset the database wasn't udpated to remove this folder.

This PR fixes that