### PR TITLE
Fix wrong `migrate-down` path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run: build ## Builds & runs the docker environment
 migrate:
 	@NODE_ENV=development knex migrate:latest --cwd ../api/src/sql/ --migrations-directory ./migrations
 migrate-down:
-	@NODE_ENV=development knex migrate:down --cwd ../api/src/sql/ --migrations-directory ../api/src/sql/migrations
+	@NODE_ENV=development knex migrate:down --cwd ../api/src/sql/ --migrations-directory ./migrations
 cleanup-sql:
 	rm -rf pg_data
 reload-data: migrate ## Reloads the input data found in ./data. NOTE: it will not remove from s3 & dynamo generated data like processed matrices, or plots. If you need a clean start, stop & re-run inframock.


### PR DESCRIPTION
#### Background
The command `make migrate-down` has the wrong relative path to the migrations folder

#### Solution
Fix the relative path