### PR TITLE
adding a postgres user

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,9 +11,6 @@ services:
       - ./pg_data:/var/lib/postgresql/data
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_USER: test
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: myapp
     user: postgres
 
   redis:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,10 @@ services:
       - ./pg_data:/var/lib/postgresql/data
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: myapp
+    user: postgres
 
   redis:
     container_name: "biomage-inframock-redis"


### PR DESCRIPTION
Adding a postgres user to docker-compose.yaml, to allow running inframock without sudo on linux