### PR TITLE
[BIOMAGE-1893] - Pass in env variables in local migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ build: ## Builds the docker-compose environment
 run: build ## Builds & runs the docker environment
 	@docker-compose $(docker_files) up --force-recreate
 migrate:
-	@NODE_ENV=development knex migrate:latest --cwd ../api/src/sql/ --migrations-directory ./migrations
+	@NODE_ENV=development AWS_ACCOUNT_ID=000000000000 AWS_REGION=eu-west-1 knex migrate:latest --cwd ../api/src/sql/ --migrations-directory ./migrations
 migrate-down:
-	@NODE_ENV=development knex migrate:rollback --all --cwd ../api/src/sql/ --migrations-directory ./migrations
+	@NODE_ENV=development AWS_ACCOUNT_ID=000000000000 AWS_REGION=eu-west-1 knex migrate:rollback --all --cwd ../api/src/sql/ --migrations-directory ./migrations
 cleanup-sql:
 	rm -rf pg_data
 reload-data: migrate ## Reloads the input data found in ./data. NOTE: it will not remove from s3 & dynamo generated data like processed matrices, or plots. If you need a clean start, stop & re-run inframock.


### PR DESCRIPTION
Issue : https://biomage.atlassian.net/browse/BIOMAGE-1893

[API PR 391](https://github.com/hms-dbmi-cellenics/api/pull/391) adds migration that requires environment variables. To make it easy to migrate for local environment, these environment variables are passed inside the `make` commands.